### PR TITLE
Log format

### DIFF
--- a/core/elog/field.go
+++ b/core/elog/field.go
@@ -1,7 +1,6 @@
 package elog
 
 import (
-	"fmt"
 	"time"
 
 	"go.uber.org/zap"
@@ -41,7 +40,7 @@ func FieldCode(value int32) Field {
 
 // 耗时时间
 func FieldCost(value time.Duration) Field {
-	return String("cost", fmt.Sprintf("%.3f", float64(value.Round(time.Microsecond))/float64(time.Millisecond)))
+	return zap.Float64("cost", float64(value.Round(time.Microsecond))/float64(time.Millisecond))
 }
 
 // FieldKey ...

--- a/server/egin/options.go
+++ b/server/egin/options.go
@@ -37,7 +37,7 @@ func recoverMiddleware(logger *elog.Component, slowQueryThresholdInMilli int64) 
 		var brokenPipe bool
 		defer func() {
 			//Latency
-			fields = append(fields, zap.Float64("cost", time.Since(beg).Seconds()))
+			fields = append(fields, zap.Int64("cost", time.Since(beg).Milliseconds()))
 			if slowQueryThresholdInMilli > 0 {
 				if cost := int64(time.Since(beg)) / 1e6; cost > slowQueryThresholdInMilli {
 					fields = append(fields, zap.Int64("slow", cost))


### PR DESCRIPTION
1. fix: FieldCost for grpc access log should be float
2. use milliseconds as the unit of FieldCost for http access log