### PR TITLE
fix the logic to determine whether a configuration file exists

### DIFF
--- a/core/econf/manager/manager.go
+++ b/core/econf/manager/manager.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"errors"
-	"github.com/gotomicro/ego/core/eapp"
 	"os"
 
 	"github.com/gotomicro/ego/core/econf"
@@ -30,7 +29,7 @@ func Register(scheme string, creator econf.DataSource) {
 
 //NewDataSource ..
 func NewDataSource(scheme, configAddr string, watch bool) (econf.DataSource, error) {
-	if scheme == DefaultScheme && configAddr == eapp.EgoConfigPath() {
+	if scheme == DefaultScheme {
 		_, err := os.Stat(configAddr)
 		if err != nil {
 			return nil, ErrDefaultConfigNotExist


### PR DESCRIPTION
Signed-off-by: devincd <505259926@qq.com>

If the configuration is a file type, there is no need to determine whether the configuration file path is consistent with `eapp.egoConfigPath()` as a determination of whether the configuration file exists or not