### PR TITLE
add: function for carrier of Header

### DIFF
--- a/core/etrace/carrier.go
+++ b/core/etrace/carrier.go
@@ -1,6 +1,7 @@
 package etrace
 
 import (
+	"net/http"
 	"strings"
 )
 
@@ -25,5 +26,26 @@ func (w MetadataReaderWriter) ForeachKey(handler func(key, val string) error) er
 		}
 	}
 
+	return nil
+}
+
+// HeaderReaderWriter ...
+type HeaderReaderWriter http.Header
+
+// Set ...
+func (w HeaderReaderWriter) Set(key, val string) {
+	h := http.Header(w)
+	h.Set(key, val)
+}
+
+// ForeachKey ...
+func (w HeaderReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range w {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/core/etrace/const.go
+++ b/core/etrace/const.go
@@ -2,6 +2,7 @@ package etrace
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
@@ -55,8 +56,8 @@ func FromIncomingContext(ctx context.Context) opentracing.StartSpanOption {
 }
 
 // HeaderExtractor ...
-func HeaderExtractor(hdr map[string][]string) opentracing.StartSpanOption {
-	sc, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, MetadataReaderWriter{MD: hdr})
+func HeaderExtractor(hdr http.Header) opentracing.StartSpanOption {
+	sc, err := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, HeaderReaderWriter(hdr))
 	if err != nil {
 		return NullStartSpanOption{}
 	}
@@ -66,9 +67,9 @@ func HeaderExtractor(hdr map[string][]string) opentracing.StartSpanOption {
 type hdrRequestKey struct{}
 
 // HeaderInjector ...
-func HeaderInjector(ctx context.Context, hdr map[string][]string) context.Context {
+func HeaderInjector(ctx context.Context, hdr http.Header) context.Context {
 	span := opentracing.SpanFromContext(ctx)
-	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, MetadataReaderWriter{MD: hdr})
+	err := opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, HeaderReaderWriter(hdr))
 	if err != nil {
 		span.LogFields(log.String("event", "inject failed"), log.Error(err))
 		return ctx


### PR DESCRIPTION
虽然已经实现了 `MetadataReaderWriter`，Header也是map结构
但是，觉得实现一个 `HTTPHeadersReaderWriter`，更加的易用

```golang
        req := httpComp.R()
	c1 := etrace.HeaderInjector(ctx, req.Header)
	info, err := req.SetContext(c1).EnableTrace().Get("/hello")
```
