### PR TITLE
fix params for 'const' type

### DIFF
--- a/core/etrace/ejaeger/config.go
+++ b/core/etrace/ejaeger/config.go
@@ -45,7 +45,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		ServiceName: eapp.Name(),
 		Sampler: &jconfig.SamplerConfig{
-			Type:  "const",
+			Type:  "probabilistic",
 			Param: 0.001,
 		},
 		Reporter: &jconfig.ReporterConfig{


### PR DESCRIPTION
jaeger 的默认config中，const 采取的参数应该是0和1，0.001实际没有生效
如果采用probabilistic采样，才能够设置成为0.001

**for "const" sampler, 0 or 1 for always false/true respectively**

```golang
// Param is a value passed to the sampler.
	// Valid values for Param field are:
	// - for "const" sampler, 0 or 1 for always false/true respectively
	// - for "probabilistic" sampler, a probability between 0 and 1
	// - for "rateLimiting" sampler, the number of spans per second
	// - for "remote" sampler, param is the same as for "probabilistic"
	//   and indicates the initial sampling rate before the actual one
	//   is received from the mothership.
```