### PR TITLE
fix: 优化egrpc在debug和ego_debug双重条件限制下debug日志输出逻辑

### DIFF
--- a/client/egrpc/config.go
+++ b/client/egrpc/config.go
@@ -18,7 +18,6 @@ type Config struct {
 	DialTimeout                  time.Duration // 连接超时，默认3s
 	ReadTimeout                  time.Duration // 读超时，默认1s
 	SlowLogThreshold             time.Duration // 慢日志记录的阈值，默认600ms
-	Debug                        bool          // 是否开启调试，默认不开启，开启后并加上export EGO_DEBUG=true，可以看到每次请求，配置名、地址、耗时、请求数据、响应数据
 	EnableBlock                  bool          // 是否开启阻塞，默认开启
 	EnableWithInsecure           bool          // 是否开启非安全传输，默认开启
 	EnableMetricInterceptor      bool          // 是否开启监控，默认开启
@@ -44,7 +43,6 @@ func DefaultConfig() *Config {
 		DialTimeout:                  time.Second * 3,
 		ReadTimeout:                  xtime.Duration("1s"),
 		SlowLogThreshold:             xtime.Duration("600ms"),
-		Debug:                        false,
 		EnableBlock:                  true,
 		EnableTraceInterceptor:       true,
 		EnableWithInsecure:           true,

--- a/client/egrpc/container.go
+++ b/client/egrpc/container.go
@@ -1,11 +1,12 @@
 package egrpc
 
 import (
-	"github.com/gotomicro/ego/core/transport"
 	"google.golang.org/grpc"
 
+	"github.com/gotomicro/ego/core/eapp"
 	"github.com/gotomicro/ego/core/econf"
 	"github.com/gotomicro/ego/core/elog"
+	"github.com/gotomicro/ego/core/transport"
 )
 
 // Option 可选项
@@ -54,7 +55,7 @@ func (c *Container) Build(options ...Option) *Component {
 	// 默认日志
 	options = append(options, WithDialOption(grpc.WithChainUnaryInterceptor(loggerUnaryClientInterceptor(c.logger, c.config))))
 
-	if c.config.Debug {
+	if eapp.IsDevelopmentMode() {
 		options = append(options, WithDialOption(grpc.WithChainUnaryInterceptor(debugUnaryClientInterceptor(c.name, c.config.Addr))))
 	}
 

--- a/client/egrpc/interceptor.go
+++ b/client/egrpc/interceptor.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/gotomicro/ego/core/transport"
-	"github.com/gotomicro/ego/internal/tools"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"google.golang.org/grpc"
@@ -22,8 +20,10 @@ import (
 	"github.com/gotomicro/ego/core/elog"
 	"github.com/gotomicro/ego/core/emetric"
 	"github.com/gotomicro/ego/core/etrace"
+	"github.com/gotomicro/ego/core/transport"
 	"github.com/gotomicro/ego/core/util/xdebug"
 	"github.com/gotomicro/ego/core/util/xstring"
+	"github.com/gotomicro/ego/internal/tools"
 )
 
 // metricUnaryClientInterceptor returns grpc unary request metrics collector interceptor
@@ -64,11 +64,6 @@ func metricUnaryClientInterceptor(name string) func(ctx context.Context, method 
 // debugUnaryClientInterceptor returns grpc unary request request and response details interceptor
 func debugUnaryClientInterceptor(compName, addr string) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		// 如果不是调试模式，跳出
-		if !eapp.IsDevelopmentMode() {
-			return nil
-		}
-
 		var p peer.Peer
 		beg := time.Now()
 		err := invoker(ctx, method, req, reply, cc, append(opts, grpc.Peer(&p))...)
@@ -78,7 +73,6 @@ func debugUnaryClientInterceptor(compName, addr string) grpc.UnaryClientIntercep
 		} else {
 			log.Println("grpc.response", xdebug.MakeReqResInfoV2(6, compName, addr, cost, method+" | "+fmt.Sprintf("%v", req), reply))
 		}
-
 		return err
 	}
 }

--- a/client/egrpc/option.go
+++ b/client/egrpc/option.go
@@ -41,13 +41,6 @@ func WithReadTimeout(t time.Duration) Option {
 	}
 }
 
-// WithDebug setting if enable debug mode
-func WithDebug(enableDebug bool) Option {
-	return func(c *Container) {
-		c.config.Debug = enableDebug
-	}
-}
-
 // WithDialOption setting grpc dial options
 func WithDialOption(opts ...grpc.DialOption) Option {
 	return func(c *Container) {


### PR DESCRIPTION
- 删除 client gRPC 里面的 debug 配置，改用全局 EGO_DEBUG 作为是否进行 debug 日志输出的判断条件
- 修复由于 debug = true 并且 EGO_DEBUG = false 情况下产生的 gRPC 空数据返回问题