### PR TITLE
style: 恢复WithDebug方法

### DIFF
--- a/client/egrpc/option.go
+++ b/client/egrpc/option.go
@@ -41,6 +41,13 @@ func WithReadTimeout(t time.Duration) Option {
 	}
 }
 
+// WithDebug setting if enable debug mode
+func WithDebug(enableDebug bool) Option {
+	return func(c *Container) {
+		// for version compatibility
+	}
+}
+
 // WithDialOption setting grpc dial options
 func WithDialOption(opts ...grpc.DialOption) Option {
 	return func(c *Container) {


### PR DESCRIPTION
在使用 ego-component@v0.2.2 中 msso 组件时，遇到 WithDebug 的方法调用，上次修复 gRPC debug 模式问题的时候，直接删除了该方法，导致了兼容问题。目前的方案是恢复该函数，但是不执行任务操作。