### PR TITLE
support parse flags with arguments

### DIFF
--- a/core/eflag/flag.go
+++ b/core/eflag/flag.go
@@ -71,6 +71,11 @@ func Parse() error {
 	return flagset.Parse()
 }
 
+// ParseWithArgs parses the flagset with given args.
+func ParseWithArgs(arguments []string) error {
+	return flagset.ParseWithArgs(arguments)
+}
+
 // Lookup lookup flag value by name
 // priority: flag > env > default
 func (fs *FlagSet) Lookup(name string) *flag.Flag {
@@ -79,6 +84,11 @@ func (fs *FlagSet) Lookup(name string) *flag.Flag {
 
 // Parse parses provided flagset.
 func (fs *FlagSet) Parse() error {
+	return fs.ParseWithArgs(os.Args[1:])
+}
+
+// ParseWithArgs parses provided flagset with given args.
+func (fs *FlagSet) ParseWithArgs(arguments []string) error {
 	if fs.Parsed() {
 		return nil
 	}
@@ -87,7 +97,7 @@ func (fs *FlagSet) Parse() error {
 	}
 
 	// 解析命令行参数
-	if err := fs.FlagSet.Parse(os.Args[1:]); err != nil {
+	if err := fs.FlagSet.Parse(arguments); err != nil {
 		return err
 	}
 

--- a/core/eflag/flag_test.go
+++ b/core/eflag/flag_test.go
@@ -234,6 +234,47 @@ func TestNewFlagSet(t *testing.T) {
 	assert.True(t, assert.ObjectsAreEqual(flag.CommandLine, obj2.FlagSet))
 }
 
+func TestParseWithArgs(t *testing.T) {
+	resetFlagSet()
+	Register(&BoolFlag{
+		Name:    "bool",
+		Usage:   "--bool",
+		Default: false,
+		Action:  func(name string, fs *FlagSet) {},
+	})
+	err := ParseWithArgs([]string{"--bool"})
+	assert.NoError(t, err)
+	boolFlag, err := BoolE("bool")
+	assert.NoError(t, err)
+	assert.Equal(t, true, boolFlag)
+
+	resetFlagSet()
+	Register(&BoolFlag{
+		Name:    "bool",
+		Usage:   "--bool",
+		Default: true,
+		Action:  func(name string, fs *FlagSet) {},
+	})
+	err = ParseWithArgs([]string{"--bool=false"})
+	assert.NoError(t, err)
+	boolFlag, err = BoolE("bool")
+	assert.NoError(t, err)
+	assert.Equal(t, false, boolFlag)
+
+	resetFlagSet()
+	Register(&StringFlag{
+		Name:    "string",
+		Usage:   "--string",
+		Default: "world",
+		Action:  func(name string, fs *FlagSet) {},
+	})
+	err = ParseWithArgs([]string{"--string", "hello"})
+	assert.NoError(t, err)
+	strFlag, err := StringE("string")
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", strFlag)
+}
+
 func resetFlagSet() {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flagObj := NewFlagSet(flag.CommandLine)

--- a/ego.go
+++ b/ego.go
@@ -54,6 +54,7 @@ type opts struct {
 	afterStopClean    []func() error  // 运行停止后清理
 	stopTimeout       time.Duration   // 运行停止超时时间
 	shutdownSignals   []os.Signal
+	arguments         []string // 命令行参数
 }
 
 //go:generate protoc -I. --go_out=module=github.com/gotomicro/ego/core/eerrors,Mcore/eerrors/errors.proto=github.com/gotomicro/ego/core/eerrors:core/eerrors core/eerrors/errors.proto
@@ -83,6 +84,7 @@ func New(options ...Option) *Ego {
 			afterStopClean:  make([]func() error, 0),
 			stopTimeout:     xtime.Duration("5s"),
 			shutdownSignals: shutdownSignals,
+			arguments:       os.Args[1:],
 		},
 	}
 

--- a/ego_function.go
+++ b/ego_function.go
@@ -9,12 +9,14 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/gotomicro/ego/core/esentinel"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/gotomicro/ego/core/esentinel"
+
 	sentinelMetrics "github.com/alibaba/sentinel-golang/metrics"
+
 	"github.com/gotomicro/ego/core/constant"
 	"github.com/gotomicro/ego/core/eapp"
 	"github.com/gotomicro/ego/core/econf"
@@ -148,7 +150,7 @@ func (e *Ego) parseFlags() error {
 		Default: "0.0.0.0",
 		Action:  func(string, *eflag.FlagSet) {},
 	})
-	return eflag.Parse()
+	return eflag.ParseWithArgs(e.opts.arguments)
 }
 
 // loadConfig init

--- a/ego_option.go
+++ b/ego_option.go
@@ -22,6 +22,13 @@ func WithDisableBanner(disableBanner bool) Option {
 	}
 }
 
+// WithArguments 传入arguments
+func WithArguments(arguments []string) Option {
+	return func(a *Ego) {
+		a.opts.arguments = arguments
+	}
+}
+
 // WithDisableFlagConfig 禁止config
 func WithDisableFlagConfig(disableFlagConfig bool) Option {
 	return func(a *Ego) {

--- a/ego_option_test.go
+++ b/ego_option_test.go
@@ -46,6 +46,18 @@ func TestWithHang(t *testing.T) {
 	}
 }
 
+func TestWithArguments(t *testing.T) {
+	//arguments default
+	app := New()
+	assert.Equal(t, os.Args[1:], app.opts.arguments)
+
+	//arguments set
+	app = New(
+		WithArguments([]string{"--foo", "bar"}),
+	)
+	assert.Equal(t, []string{"--foo", "bar"}, app.opts.arguments)
+}
+
 func TestWithDisableBanner(t *testing.T) {
 	type args struct {
 		disableBanner bool


### PR DESCRIPTION
某些场景下我们可能需要将 ego app 运行于 sub command 下（如 `./myapp ego-server --config=config.toml`），如果直接用 `os.Args[1:]` 来解析 flags，会将 sub command 当做 flag 解析从而无法正常解析到 flag

增加 `WithArguments` 可自由传入 arguments，方便业务自行将 flag 部分的 arguments 传给 ego 进行解析
