### PR TITLE
Support `OTEL_SERVICE_NAME` env to set otel serviceName

### DIFF
--- a/core/etrace/otel/config.go
+++ b/core/etrace/otel/config.go
@@ -56,7 +56,7 @@ func Load(key string) *Config {
 // DefaultConfig ...
 func DefaultConfig() *Config {
 	return &Config{
-		ServiceName: eapp.Name(),
+		ServiceName: ienv.EnvOrStr("OTEL_SERVICE_NAME", eapp.Name()),
 		Jaeger: jaegerConfig{
 			AgentHost:         ienv.EnvOrStr("OTEL_EXPORTER_JAEGER_AGENT_HOST", "localhost"),
 			AgentPort:         ienv.EnvOrStr("OTEL_EXPORTER_JAEGER_AGENT_PORT", "6831"),


### PR DESCRIPTION
支持 `OTEL_SERVICE_NAME` 环境变量覆盖服务名

某些场景下我们可能会使用同一个 app 不同的 command 运行多个进程，扮演多个服务，需要区分 serviceName