### PR TITLE
perf: the `config.Writer` should be used in preference in elog Build

### DIFF
--- a/core/elog/container.go
+++ b/core/elog/container.go
@@ -55,7 +55,8 @@ func (c *Container) Build(options ...Option) *Component {
 	}
 
 	// 设置ego日志的log name，用于stderr区分系统日志和业务日志
-	if eapp.EgoLogWriter() == "stderr" {
+	// config writer setting > env writer setting
+	if c.config.Writer == "stderr" || (c.config.Writer == "" && eapp.EgoLogWriter() == "stderr") {
 		c.config.fields = append(c.config.fields, FieldLogName(c.config.Name))
 	}
 


### PR DESCRIPTION
`defaultConfig()` has been read `Writer` from env
https://github.com/gotomicro/ego/blob/ee9e1c3a37b6f49f6f44d78b3dae7bb26752a092/core/elog/config.go#L55

so we should give preference to `config.Writer`

---

https://github.com/gotomicro/ego/blob/435ef98e298b1a46e0ec050c451b63edc0080f58/core/elog/container.go#L58-L60
If we don't set env but do set config, the `Writer` here will be ignored