### PR TITLE
Support relabel path of ehttp client to solve the high cardinality issue

### DIFF
--- a/client/ehttp/config.go
+++ b/client/ehttp/config.go
@@ -1,6 +1,7 @@
 package ehttp
 
 import (
+	"regexp"
 	"runtime"
 	"time"
 
@@ -21,6 +22,13 @@ type Config struct {
 	EnableKeepAlives           bool          // 是否开启长连接，默认打开
 	EnableAccessInterceptor    bool          // 是否开启记录请求数据，默认不开启
 	EnableAccessInterceptorRes bool          // 是否开启记录响应参数，默认不开启
+	PathRelabel                []Relabel     // path 重命名 (metric 用)
+}
+
+type Relabel struct {
+	Match       string
+	matchReg    *regexp.Regexp
+	Replacement string
 }
 
 // DefaultConfig ...

--- a/client/ehttp/container.go
+++ b/client/ehttp/container.go
@@ -1,6 +1,8 @@
 package ehttp
 
 import (
+	"regexp"
+
 	"github.com/gotomicro/ego/core/econf"
 	"github.com/gotomicro/ego/core/elog"
 )
@@ -30,6 +32,13 @@ func Load(key string) *Container {
 	if err := econf.UnmarshalKey(key, &c.config); err != nil {
 		c.logger.Panic("parse config error", elog.FieldErr(err), elog.FieldKey(key))
 		return c
+	}
+	for idx, relabel := range c.config.PathRelabel {
+		if reg, err := regexp.Compile(relabel.Match); err == nil {
+			c.config.PathRelabel[idx].matchReg = reg
+		} else {
+			c.logger.Panic("parse path relabel error", elog.FieldErr(err), elog.FieldKey(key))
+		}
 	}
 	c.name = key
 	return c

--- a/client/ehttp/options.go
+++ b/client/ehttp/options.go
@@ -85,3 +85,10 @@ func WithEnableAccessInterceptorRes(enableAccessInterceptorRes bool) Option {
 		c.config.EnableAccessInterceptorRes = enableAccessInterceptorRes
 	}
 }
+
+// WithPathRelabel 设置路径重命名
+func WithPathRelabel(match string, replacement string) Option {
+	return func(c *Container) {
+		c.config.PathRelabel = append(c.config.PathRelabel, Relabel{Match: match, Replacement: replacement})
+	}
+}


### PR DESCRIPTION
HTTP 客户端的请求的 path 里如果有参数会在指标系统里产生高基数问题

一般场景下，通过在 url 里加上参数占位符，并设置 path 参数可以解决这一问题，如：
```
comp.R().SetPathParam("foo", "bar").Get("/id/{foo}")
```
这样拦截器里获取的 url path 会是 `/id{foo}`

但有些场景，如：使用 ehttp 客户端转发请求时，我们并不方便使用上述方式一个一个指定请求 url，这时候可能需要支持配置 path 的重写规则，匹配带参数 path 重命名为统一的 path

**注意使用该配置会带来一定的性能开销**