### PR TITLE
modify DefaultLogger default callerSkip to 2

### DIFF
--- a/core/elog/elog_api.go
+++ b/core/elog/elog_api.go
@@ -13,7 +13,7 @@ func init() {
 	registry = make(map[string]WriterBuilder)
 	Register(&stderrWriterBuilder{})
 	Register(&rotateWriterBuilder{})
-	DefaultLogger = DefaultContainer().Build(WithFileName(DefaultLoggerName))
+	DefaultLogger = DefaultContainer().Build(WithFileName(DefaultLoggerName), WithCallSkip(2)) // DefaultLogger 默认为2层
 	EgoLogger = DefaultContainer().Build(WithFileName(EgoLoggerName))
 }
 

--- a/core/elog/elog_option.go
+++ b/core/elog/elog_option.go
@@ -55,3 +55,10 @@ func WithEncoderConfig(encoderConfig *zapcore.EncoderConfig) Option {
 		c.config.encoderConfig = encoderConfig
 	}
 }
+
+// WithCallSkip 支持自定义调用层级
+func WithCallSkip(callerSkip int) Option {
+	return func(c *Container) {
+		c.config.CallerSkip = callerSkip
+	}
+}

--- a/ego_function.go
+++ b/ego_function.go
@@ -221,7 +221,7 @@ func loadConfig() error {
 // initLogger init application and Ego logger
 func (e *Ego) initLogger() error {
 	if econf.Get(e.opts.configPrefix+"logger.default") != nil {
-		elog.DefaultLogger = elog.Load(e.opts.configPrefix + "logger.default").Build()
+		elog.DefaultLogger = elog.Load(e.opts.configPrefix + "logger.default").Build(elog.WithCallSkip(2)) // DefaultLogger 默认为2层
 		elog.EgoLogger.Info("reinit default logger", elog.FieldComponent(elog.PackageName))
 		e.opts.afterStopClean = append(e.opts.afterStopClean, elog.DefaultLogger.Flush)
 	}


### PR DESCRIPTION
### 背景 
我们在默认配置中配置了打印日志产生的caller，希望能够快速定位当前日志打印的位置

```bash
[logger.default]
   debug = true
   enableAddCaller = true
```

我们使用的是日志打印方式为

```bash
elog.Info("hello")
```

日志样式

```bash
1686295543      INFO    elog/elog_api.go:22     hello
```

可以很明显的看出，call的位置不太对(elog/elog_api.go:22),我们期望的是显示我们打印日志的地方的位置和行数，但实际
显示的是```github.com/gotomicro/ego/core/elog/elog_api.go```打Info的位置

```go
// Info ...
func Info(msg string, fields ...Field) {
	DefaultLogger.Info(msg, fields...)
}
```

从这段源代码也可以很容易的看出来，该位置并没有直接调用zap.Logger下的Info()去打印，而是手动调用了```DefaultLogger```这个全局变量，而我们本身到zap那儿包了一层，所以从我们打印的位置到最终的zap包，一共有两层，
同时```callerSkip```这个值的默认值设置的是1（只往上追溯了一层），所以导致了这个问题的发生。

在这里，有四个解决方案

1，我们打印的日志的方式调整为

```go
elog.DefaultLogger.Info("hello")
```

这样可以解决上述的问题，但是对业务方来说很不友好，增加了使用者的心智负担，也不符合常规打日志的习惯

2，我们在配置文件手动增加配置

```toml
[logger.default]
   debug = true
   enableAddCaller = true
   callSkip = 2 
```

通过配置文件的方式将默认日志的callSkip置为2，这样也可以解决问题

但是又带来了一个新的烦恼，因为大多数人使用框架都是无脑上的那种，根本不会对默认日志去增加配置文件控制这种细微的参数，并不是每个人都能对callSkip这个参数有一个很好的理解，甚至来说大部分项目的配置文件里面压根儿都不会log相关的配置

类似于enableAddCaller这种控制我们都是通过环境变量去控制的

3，修改defaultConfig里面的CallerSkip为2

这个方案肯定是不可取的，虽然能解决DefaultLogger的问题

但是只有类似于DefaultLogger这种特殊的情况才有这个问题，这样改了会影响我们自定义的日志以及本身的框架日志

4，在加载DefaultLogger的时候将DefaultLogger的CallerSkip默认设置为2


---
基于上面的问题，我们希望的是DefaultLogger的callSkip默认设置为2，故增加了WithCallSkip函数，并在框架侧初始化DefaultLogger的两个地方加上WithCallSkip(2)的配置来解决上述的问题。