### PR TITLE
log add WithDefaultFileName

### DIFF
--- a/core/elog/elog_option.go
+++ b/core/elog/elog_option.go
@@ -14,6 +14,17 @@ func WithFileName(name string) Option {
 	}
 }
 
+// WithDefaultFileName 设置默认的文件名,只有在配置的文件名不存在或者为兜底默认值的时候才会生效
+func WithDefaultFileName(name string) Option {
+	return func(c *Container) {
+		// 只有当配置的文件名为空或者为兜底默认值的时候才会生效
+		// 因为Container的默认值为DefaultLoggerName 如果配置了文件名，那么就不会使用默认的文件名了
+		if c.config.Name == "" || c.config.Name == DefaultLoggerName {
+			c.config.Name = name
+		}
+	}
+}
+
 // WithDebug 设置在命令行显示
 func WithDebug(debug bool) Option {
 	return func(c *Container) {

--- a/ego_function.go
+++ b/ego_function.go
@@ -227,7 +227,7 @@ func (e *Ego) initLogger() error {
 	}
 
 	if econf.Get(e.opts.configPrefix+"logger.ego") != nil {
-		elog.EgoLogger = elog.Load(e.opts.configPrefix + "logger.ego").Build(elog.WithFileName(elog.EgoLoggerName))
+		elog.EgoLogger = elog.Load(e.opts.configPrefix + "logger.ego").Build(elog.WithDefaultFileName(elog.EgoLoggerName))
 		elog.EgoLogger.Info("reinit ego logger", elog.FieldComponent(elog.PackageName))
 		e.opts.afterStopClean = append(e.opts.afterStopClean, elog.EgoLogger.Flush)
 	}


### PR DESCRIPTION
- 目前系统日志的初始化的时候，当配置文件存在的时候，也是强制指定了文件名称为```ego.sys```
```go
func init() {
        ... ....
	EgoLogger = DefaultContainer().Build(WithFileName(EgoLoggerName))
}

func (e *Ego) initLogger() error {
        ... ....
	if econf.Get(e.opts.configPrefix+"logger.ego") != nil {
		elog.EgoLogger = elog.Load(e.opts.configPrefix + "logger.ego").Build(elog.WithFileName(elog.EgoLoggerName))
		elog.EgoLogger.Info("reinit ego logger", elog.FieldComponent(elog.PackageName))
		e.opts.afterStopClean = append(e.opts.afterStopClean, elog.EgoLogger.Flush)
	}
	return nil
}
```
- 很多时候业务方有很强烈的手动修改系统日志文件名称的诉求，比如说当前采集日志的agent不支持.sys的后缀等
- 同时又为了兼容我们在配置系统日志的时候，忘记配置文件名称，从而让系统日志打印到了default.log里面
- 故增加了```WithDefaultFileName```函数，只有在配置的文件名不存在或者为兜底默认值的时候才会生效，不会破坏原来的日志结构，同时支持了业务方根据配置文件指定自己想要的文件名，并且在业务方遗漏了```name```的配置时，还是会使用的默认的```ego.sys```作为兜底。