### PR TITLE
SetTextMapPropagator

### DIFF
--- a/core/etrace/trace.go
+++ b/core/etrace/trace.go
@@ -26,6 +26,7 @@ var (
 func SetGlobalTracer(tp trace.TracerProvider) {
 	globalTracer = registeredTracer{true}
 	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
 }
 
 // IsGlobalTracerRegistered returns a `bool` to indicate if a tracer has been globally registered


### PR DESCRIPTION
初始化 tracer 的时候同时 SetTextMapPropagator，以便其他地方可以直接使用 `otel.GetTextMapPropagator()`