### PR TITLE
register add depEnv to metadata

### DIFF
--- a/core/constant/env.go
+++ b/core/constant/env.go
@@ -38,4 +38,6 @@ const (
 	// EgoDefaultConfigExt defines default config file extension, support ".toml"，".yaml"，".json",
 	// EgoDefaultConfigExt effective only the configuration file path without extension name
 	EgoDefaultConfigExt = "EGO_DEFAULT_CONFIG_EXT"
+	// EgoDeploymentEnv defines deployment environment, such as "k8s", "ecs"
+	EgoDeploymentEnv = "EGO_DEPLOYMENT_ENV"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 
 	"github.com/gotomicro/ego/core/constant"
@@ -164,5 +165,6 @@ func defaultServiceInfo() ServiceInfo {
 	si.Metadata["buildTime"] = eapp.BuildTime()
 	si.Metadata["appVersion"] = eapp.AppVersion()
 	si.Metadata["egoVersion"] = eapp.EgoVersion()
+	si.Metadata["depEnv"] = os.Getenv(constant.EgoDeploymentEnv) // 部署环境
 	return si
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -43,6 +43,7 @@ func TestServiceInfo(t *testing.T) {
 					"buildTime":  "",
 					"egoVersion": "unknown version",
 					"key":        "val",
+					"depEnv":     "",
 					"startTime":  xtime.TS.Format(time.Now()),
 				},
 			},


### PR DESCRIPTION
我们线上ecs和k8s目前网络不通

所以我们有一个中心Prometheus，ecs和k8s上面各部署一个Prometheus把数据push到中心Prometheus

但是呢，我们的etcd又是通的，即注册到了同一个etcd里面

所以两个环境的confd处理监控数据的时候，无法区分哪个是ecs哪个是k8s，都能拉到同一份数据

要区分的话，首先肯定是注册前缀可以区分

但是有一个问题，未来网络扁平化落地后网络互通实现后，在服务从ecs切到k8s时，

由于注册键不一样，业务方也要跟着改配置