### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/client/egrpc/interceptor.go
+++ b/client/egrpc/interceptor.go
@@ -36,8 +36,8 @@ import (
 )
 
 // metricUnaryClientInterceptor returns grpc unary request metrics collector interceptor
-func (c *Container) metricUnaryClientInterceptor() func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func (c *Container) metricUnaryClientInterceptor() func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		beg := time.Now()
 		emetric.ClientStartedCounter.Inc(emetric.TypeGRPCUnary, c.name, method, cc.Target())
 		err := invoker(ctx, method, req, reply, cc, opts...)
@@ -53,7 +53,7 @@ func (c *Container) metricUnaryClientInterceptor() func(ctx context.Context, met
 
 // debugUnaryClientInterceptor returns grpc unary request request and response details interceptor
 func (c *Container) debugUnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		var p peer.Peer
 		beg := time.Now()
 		err := invoker(ctx, method, req, reply, cc, append(opts, grpc.Peer(&p))...)
@@ -74,7 +74,7 @@ func (c *Container) traceUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 		egrpcinteceptor.RPCSystemGRPC,
 		egrpcinteceptor.GRPCKindUnary,
 	}
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
 		md, ok := metadata.FromOutgoingContext(ctx)
 		if !ok {
 			md = metadata.New(nil)
@@ -104,7 +104,7 @@ func (c *Container) traceUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 
 // defaultUnaryClientInterceptor returns interceptor inject app name
 func (c *Container) defaultUnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md
 		ctx = metadata.AppendToOutgoingContext(ctx, "app", eapp.Name())
 		// if c.config.EnableCPUUsage {
@@ -142,7 +142,7 @@ type clientStream struct {
 	sentMessageID     int
 }
 
-func (w *clientStream) RecvMsg(m interface{}) error {
+func (w *clientStream) RecvMsg(m any) error {
 	err := w.ClientStream.RecvMsg(m)
 
 	if err == nil && !w.desc.ServerStreams {
@@ -159,7 +159,7 @@ func (w *clientStream) RecvMsg(m interface{}) error {
 	return err
 }
 
-func (w *clientStream) SendMsg(m interface{}) error {
+func (w *clientStream) SendMsg(m any) error {
 	err := w.ClientStream.SendMsg(m)
 
 	w.sentMessageID++
@@ -294,7 +294,7 @@ func (c *Container) defaultStreamClientInterceptor() grpc.StreamClientIntercepto
 
 // timeoutUnaryClientInterceptor settings timeout
 func (c *Container) timeoutUnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		// 若无自定义超时设置，默认设置超时
 		_, ok := ctx.Deadline()
 		if !ok {
@@ -308,7 +308,7 @@ func (c *Container) timeoutUnaryClientInterceptor() grpc.UnaryClientInterceptor 
 
 // loggerUnaryClientInterceptor returns log interceptor for logging
 func (c *Container) loggerUnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, res interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
+	return func(ctx context.Context, method string, req, res any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) (err error) {
 		var beg = time.Now()
 		var fields []elog.Field
 		var event = "normal"
@@ -397,7 +397,7 @@ func (c *Container) loggerUnaryClientInterceptor() grpc.UnaryClientInterceptor {
 
 // customHeader 自定义header头
 func customHeader(egoLogExtraKeys []string) grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, res interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, res any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		for _, key := range egoLogExtraKeys {
 			if value := tools.GrpcHeaderValue(ctx, key); value != "" {
 				if ctx.Value(key) != nil {

--- a/client/egrpc/interceptor_test.go
+++ b/client/egrpc/interceptor_test.go
@@ -30,7 +30,7 @@ func Test_customHeader(t *testing.T) {
 
 	cc := new(grpc.ClientConn)
 	err := interceptor(ctx, "/foo", nil, nil, cc,
-		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			info := tools.GrpcHeaderValue(ctx, "X-Ego-Uid")
 			assert.Equal(t, "9527", info)
 			return nil
@@ -44,7 +44,7 @@ func TestMetric(t *testing.T) {
 	interceptor := cmp.metricUnaryClientInterceptor()
 	cc := new(grpc.ClientConn)
 	err := interceptor(context.Background(), "/foo", nil, nil, cc,
-		func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+		func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
 			return nil
 		})
 	assert.Nil(t, err)

--- a/client/egrpc/resolver/stat.go
+++ b/client/egrpc/resolver/stat.go
@@ -21,7 +21,7 @@ func init() {
 // stats
 func stats() (stats map[string][]resolver.Address) {
 	stats = make(map[string][]resolver.Address)
-	instances.Range(func(key, val interface{}) bool {
+	instances.Range(func(key, val any) bool {
 		name := key.(string)
 		addresses := val.([]resolver.Address)
 		stats[name] = addresses

--- a/core/econf/api.go
+++ b/core/econf/api.go
@@ -27,7 +27,7 @@ type DataSource interface {
 }
 
 // Unmarshaller ...
-type Unmarshaller = func([]byte, interface{}) error
+type Unmarshaller = func([]byte, any) error
 
 var defaultConfiguration = New()
 
@@ -54,7 +54,7 @@ func LoadFromReader(r io.Reader, unmarshaller Unmarshaller) error {
 }
 
 // Apply ...
-func Apply(conf map[string]interface{}) error {
+func Apply(conf map[string]any) error {
 	return defaultConfiguration.apply(conf)
 }
 
@@ -64,7 +64,7 @@ func Reset() {
 }
 
 // Traverse ...
-func Traverse(sep string) map[string]interface{} {
+func Traverse(sep string) map[string]any {
 	return defaultConfiguration.traverse(sep)
 }
 
@@ -79,11 +79,11 @@ func Debug(sep string) {
 }
 
 // Get returns an interface. For a specific value use one of the Get____ methods.
-func Get(key string) interface{} {
+func Get(key string) any {
 	return defaultConfiguration.Get(key)
 }
 
 // Set sets config value for key
-func Set(key string, val interface{}) {
+func Set(key string, val any) {
 	_ = defaultConfiguration.Set(key, val)
 }

--- a/core/econf/conf.go
+++ b/core/econf/conf.go
@@ -22,7 +22,7 @@ const PackageName = "core.econf"
 // Configuration ...
 type Configuration struct {
 	mu        sync.RWMutex
-	override  map[string]interface{}
+	override  map[string]any
 	keyDelim  string
 	rawConfig []byte
 	keyMap    *sync.Map
@@ -38,7 +38,7 @@ const (
 // New constructs a new Configuration with provider.
 func New() *Configuration {
 	return &Configuration{
-		override:  make(map[string]interface{}),
+		override:  make(map[string]any),
 		keyDelim:  defaultKeyDelim,
 		keyMap:    &sync.Map{},
 		onChanges: make([]func(*Configuration), 0),
@@ -114,7 +114,7 @@ func (c *Configuration) LoadFromDataSource(ds DataSource, unmarshaller Unmarshal
 // Load ...
 func (c *Configuration) Load(content []byte, unmarshal Unmarshaller) error {
 	c.rawConfig = content
-	configuration := make(map[string]interface{})
+	configuration := make(map[string]any)
 	if err := unmarshal(content, &configuration); err != nil {
 		return err
 	}
@@ -130,11 +130,11 @@ func (c *Configuration) LoadFromReader(reader io.Reader, unmarshaller Unmarshall
 	return c.Load(content, unmarshaller)
 }
 
-func (c *Configuration) apply(conf map[string]interface{}) error {
+func (c *Configuration) apply(conf map[string]any) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	var changes = make(map[string]interface{})
+	var changes = make(map[string]any)
 
 	xmap.MergeStringMap(c.override, conf)
 	for k, v := range c.traverse(c.keyDelim) {
@@ -152,7 +152,7 @@ func (c *Configuration) apply(conf map[string]interface{}) error {
 	return nil
 }
 
-func (c *Configuration) notifyChanges(changes map[string]interface{}) {
+func (c *Configuration) notifyChanges(changes map[string]any) {
 	var changedWatchPrefixMap = map[string]struct{}{}
 
 	for watchPrefix := range c.watchers {
@@ -173,7 +173,7 @@ func (c *Configuration) notifyChanges(changes map[string]interface{}) {
 }
 
 // Set ...
-func (c *Configuration) Set(key string, val interface{}) error {
+func (c *Configuration) Set(key string, val any) error {
 	paths := strings.Split(key, c.keyDelim)
 	lastKey := paths[len(paths)-1]
 	m := deepSearch(c.override, paths[:len(paths)-1])
@@ -182,18 +182,18 @@ func (c *Configuration) Set(key string, val interface{}) error {
 	// c.keyMap.Store(key, val)
 }
 
-func deepSearch(m map[string]interface{}, path []string) map[string]interface{} {
+func deepSearch(m map[string]any, path []string) map[string]any {
 	for _, k := range path {
 		m2, ok := m[k]
 		if !ok {
-			m3 := make(map[string]interface{})
+			m3 := make(map[string]any)
 			m[k] = m3
 			m = m3
 			continue
 		}
-		m3, ok := m2.(map[string]interface{})
+		m3, ok := m2.(map[string]any)
 		if !ok {
-			m3 = make(map[string]interface{})
+			m3 = make(map[string]any)
 			m[k] = m3
 		}
 		m = m3
@@ -202,7 +202,7 @@ func deepSearch(m map[string]interface{}, path []string) map[string]interface{} 
 }
 
 // Get returns the value associated with the key
-func (c *Configuration) Get(key string) interface{} {
+func (c *Configuration) Get(key string) any {
 	return c.find(key)
 }
 
@@ -287,22 +287,22 @@ func (c *Configuration) GetStringSlice(key string) []string {
 }
 
 // GetSlice returns the value associated with the key as a slice of strings with default defaultConfiguration.
-func GetSlice(key string) []interface{} {
+func GetSlice(key string) []any {
 	return defaultConfiguration.GetSlice(key)
 }
 
 // GetSlice returns the value associated with the key as a slice of strings.
-func (c *Configuration) GetSlice(key string) []interface{} {
+func (c *Configuration) GetSlice(key string) []any {
 	return cast.ToSlice(c.Get(key))
 }
 
 // GetStringMap returns the value associated with the key as a map of interfaces with default defaultConfiguration.
-func GetStringMap(key string) map[string]interface{} {
+func GetStringMap(key string) map[string]any {
 	return defaultConfiguration.GetStringMap(key)
 }
 
 // GetStringMap returns the value associated with the key as a map of interfaces.
-func (c *Configuration) GetStringMap(key string) map[string]interface{} {
+func (c *Configuration) GetStringMap(key string) map[string]any {
 	return cast.ToStringMap(c.Get(key))
 }
 
@@ -317,7 +317,7 @@ func (c *Configuration) GetStringMapString(key string) map[string]string {
 }
 
 // GetSliceStringMap returns the value associated with the slice of maps.
-func (c *Configuration) GetSliceStringMap(key string) []map[string]interface{} {
+func (c *Configuration) GetSliceStringMap(key string) []map[string]any {
 	return tools.ToSliceStringMap(c.Get(key))
 }
 
@@ -332,12 +332,12 @@ func (c *Configuration) GetStringMapStringSlice(key string) map[string][]string 
 }
 
 // UnmarshalWithExpect unmarshal key, returns expect if failed
-func UnmarshalWithExpect(key string, expect interface{}) interface{} {
+func UnmarshalWithExpect(key string, expect any) any {
 	return defaultConfiguration.UnmarshalWithExpect(key, expect)
 }
 
 // UnmarshalWithExpect unmarshal key, returns expect if failed
-func (c *Configuration) UnmarshalWithExpect(key string, expect interface{}) interface{} {
+func (c *Configuration) UnmarshalWithExpect(key string, expect any) any {
 	err := c.UnmarshalKey(key, expect)
 	if err != nil {
 		return expect
@@ -346,7 +346,7 @@ func (c *Configuration) UnmarshalWithExpect(key string, expect interface{}) inte
 }
 
 // UnmarshalKey takes a single key and unmarshal it into a Struct with default defaultConfiguration.
-func UnmarshalKey(key string, rawVal interface{}, opts ...Option) error {
+func UnmarshalKey(key string, rawVal any, opts ...Option) error {
 	return defaultConfiguration.UnmarshalKey(key, rawVal, opts...)
 }
 
@@ -354,7 +354,7 @@ func UnmarshalKey(key string, rawVal interface{}, opts ...Option) error {
 var ErrInvalidKey = errors.New("invalid key, maybe not exist in config")
 
 // UnmarshalKey takes a single key and unmarshal it into a Struct.
-func (c *Configuration) UnmarshalKey(key string, rawVal interface{}, opts ...Option) error {
+func (c *Configuration) UnmarshalKey(key string, rawVal any, opts ...Option) error {
 	var options = defaultContainer
 	for _, opt := range opts {
 		opt(&options)
@@ -385,7 +385,7 @@ func (c *Configuration) UnmarshalKey(key string, rawVal interface{}, opts ...Opt
 	return decoder.Decode(value)
 }
 
-func (c *Configuration) find(key string) interface{} {
+func (c *Configuration) find(key string) any {
 	dd, ok := c.keyMap.Load(key)
 	if ok {
 		return dd
@@ -400,7 +400,7 @@ func (c *Configuration) find(key string) interface{} {
 	return dd
 }
 
-func lookup(prefix string, target map[string]interface{}, data map[string]interface{}, sep string) {
+func lookup(prefix string, target map[string]any, data map[string]any, sep string) {
 	for k, v := range target {
 		pp := fmt.Sprintf("%s%s%s", prefix, sep, k)
 		if prefix == "" {
@@ -414,8 +414,8 @@ func lookup(prefix string, target map[string]interface{}, data map[string]interf
 	}
 }
 
-func (c *Configuration) traverse(sep string) map[string]interface{} {
-	data := make(map[string]interface{})
+func (c *Configuration) traverse(sep string) map[string]any {
+	data := make(map[string]any)
 	lookup("", c.override, data, sep)
 	return data
 }

--- a/core/econf/conf_test.go
+++ b/core/econf/conf_test.go
@@ -20,7 +20,7 @@ func TestSetKeyDelim(t *testing.T) {
 func TestSub(t *testing.T) {
 	c := &Configuration{
 		keyDelim: defaultKeyDelim,
-		override: map[string]interface{}{
+		override: map[string]any{
 			"key1": "hello",
 			"key2": "world",
 		},
@@ -30,7 +30,7 @@ func TestSub(t *testing.T) {
 		out := c.Sub("")
 		in := &Configuration{
 			keyDelim: defaultKeyDelim,
-			override: map[string]interface{}{},
+			override: map[string]any{},
 			keyMap:   &sync.Map{},
 		}
 		assert.Equal(t, in, out)

--- a/core/elog/component.go
+++ b/core/elog/component.go
@@ -170,7 +170,7 @@ func (logger *Component) Debug(msg string, fields ...Field) {
 
 // Debugw ...
 // Deprecated: Will be removed in future versions, use *Component.Debug instead.
-func (logger *Component) Debugw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Debugw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -179,7 +179,7 @@ func (logger *Component) Debugw(msg string, keysAndValues ...interface{}) {
 
 // Debugf ...
 // Deprecated: Will be removed in future versions, use *Component.Debug instead.
-func (logger *Component) Debugf(template string, args ...interface{}) {
+func (logger *Component) Debugf(template string, args ...any) {
 	logger.sugar.Debugf(template, args...)
 }
 
@@ -193,7 +193,7 @@ func (logger *Component) Info(msg string, fields ...Field) {
 
 // Infow ...
 // Deprecated: Will be removed in future versions, use *Component.Info instead.
-func (logger *Component) Infow(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Infow(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -202,7 +202,7 @@ func (logger *Component) Infow(msg string, keysAndValues ...interface{}) {
 
 // Infof ...
 // Deprecated: Will be removed in future versions, use *Component.Info instead.
-func (logger *Component) Infof(template string, args ...interface{}) {
+func (logger *Component) Infof(template string, args ...any) {
 	logger.sugar.Infof(template, args...)
 }
 
@@ -216,7 +216,7 @@ func (logger *Component) Warn(msg string, fields ...Field) {
 
 // Warnw ...
 // Deprecated: Will be removed in future versions, use *Component.Warn instead.
-func (logger *Component) Warnw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Warnw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -225,7 +225,7 @@ func (logger *Component) Warnw(msg string, keysAndValues ...interface{}) {
 
 // Warnf ...
 // Deprecated: Will be removed in future versions, use *Component.Warn instead.
-func (logger *Component) Warnf(template string, args ...interface{}) {
+func (logger *Component) Warnf(template string, args ...any) {
 	logger.sugar.Warnf(template, args...)
 }
 
@@ -239,7 +239,7 @@ func (logger *Component) Error(msg string, fields ...Field) {
 
 // Errorw ...
 // Deprecated: Will be removed in future versions, use *Component.Error instead.
-func (logger *Component) Errorw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Errorw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -248,7 +248,7 @@ func (logger *Component) Errorw(msg string, keysAndValues ...interface{}) {
 
 // Errorf ...
 // Deprecated: Will be removed in future versions, use *Component.Error instead.
-func (logger *Component) Errorf(template string, args ...interface{}) {
+func (logger *Component) Errorf(template string, args ...any) {
 	logger.sugar.Errorf(template, args...)
 }
 
@@ -263,7 +263,7 @@ func (logger *Component) Panic(msg string, fields ...Field) {
 
 // Panicw ...
 // Deprecated: Will be removed in future versions, use *Component.Panic instead.
-func (logger *Component) Panicw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Panicw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -272,7 +272,7 @@ func (logger *Component) Panicw(msg string, keysAndValues ...interface{}) {
 
 // Panicf ...
 // Deprecated: Will be removed in future versions, use *Component.Panic instead.
-func (logger *Component) Panicf(template string, args ...interface{}) {
+func (logger *Component) Panicf(template string, args ...any) {
 	logger.sugar.Panicf(template, args...)
 }
 
@@ -287,7 +287,7 @@ func (logger *Component) DPanic(msg string, fields ...Field) {
 
 // DPanicw ...
 // Deprecated: Will be removed in future versions, use *Component.DPanic instead.
-func (logger *Component) DPanicw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) DPanicw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -296,7 +296,7 @@ func (logger *Component) DPanicw(msg string, keysAndValues ...interface{}) {
 
 // DPanicf ...
 // Deprecated: Will be removed in future versions, use *Component.DPanic instead.
-func (logger *Component) DPanicf(template string, args ...interface{}) {
+func (logger *Component) DPanicf(template string, args ...any) {
 	logger.sugar.DPanicf(template, args...)
 }
 
@@ -312,7 +312,7 @@ func (logger *Component) Fatal(msg string, fields ...Field) {
 
 // Fatalw ...
 // Deprecated: Will be removed in future versions, use *Component.Fatal instead.
-func (logger *Component) Fatalw(msg string, keysAndValues ...interface{}) {
+func (logger *Component) Fatalw(msg string, keysAndValues ...any) {
 	if logger.IsDebugMode() {
 		msg = normalizeMessage(msg)
 	}
@@ -321,7 +321,7 @@ func (logger *Component) Fatalw(msg string, keysAndValues ...interface{}) {
 
 // Fatalf ...
 // Deprecated: Will be removed in future versions, use *Component.Fatal instead.
-func (logger *Component) Fatalf(template string, args ...interface{}) {
+func (logger *Component) Fatalf(template string, args ...any) {
 	logger.sugar.Fatalf(template, args...)
 }
 

--- a/core/elog/elog_api.go
+++ b/core/elog/elog_api.go
@@ -55,85 +55,85 @@ func Fatal(msg string, fields ...Field) {
 
 // Debugw ...
 // Deprecated: Will be removed in future versions, use Debug instead.
-func Debugw(msg string, keysAndValues ...interface{}) {
+func Debugw(msg string, keysAndValues ...any) {
 	DefaultLogger.Debugw(msg, keysAndValues...)
 }
 
 // Infow ...
 // Deprecated: Will be removed in future versions, use Info instead.
-func Infow(msg string, keysAndValues ...interface{}) {
+func Infow(msg string, keysAndValues ...any) {
 	DefaultLogger.Infow(msg, keysAndValues...)
 }
 
 // Warnw ...
 // Deprecated: Will be removed in future versions, use Warn instead.
-func Warnw(msg string, keysAndValues ...interface{}) {
+func Warnw(msg string, keysAndValues ...any) {
 	DefaultLogger.Warnw(msg, keysAndValues...)
 }
 
 // Errorw ...
 // Deprecated: Will be removed in future versions, use Error instead.
-func Errorw(msg string, keysAndValues ...interface{}) {
+func Errorw(msg string, keysAndValues ...any) {
 	DefaultLogger.Errorw(msg, keysAndValues...)
 }
 
 // Panicw ...
 // Deprecated: Will be removed in future versions, use Panic instead.
-func Panicw(msg string, keysAndValues ...interface{}) {
+func Panicw(msg string, keysAndValues ...any) {
 	DefaultLogger.Panicw(msg, keysAndValues...)
 }
 
 // DPanicw ...
 // Deprecated: Will be removed in future versions, use DPanic instead.
-func DPanicw(msg string, keysAndValues ...interface{}) {
+func DPanicw(msg string, keysAndValues ...any) {
 	DefaultLogger.DPanicw(msg, keysAndValues...)
 }
 
 // Fatalw ...
 // Deprecated: Will be removed in future versions, use Fatal instead.
-func Fatalw(msg string, keysAndValues ...interface{}) {
+func Fatalw(msg string, keysAndValues ...any) {
 	DefaultLogger.Fatalw(msg, keysAndValues...)
 }
 
 // Debugf ...
 // Deprecated: Will be removed in future versions, use Debug instead.
-func Debugf(msg string, args ...interface{}) {
+func Debugf(msg string, args ...any) {
 	DefaultLogger.Debugf(msg, args...)
 }
 
 // Infof ...
 // Deprecated: Will be removed in future versions, use Info instead.
-func Infof(msg string, args ...interface{}) {
+func Infof(msg string, args ...any) {
 	DefaultLogger.Infof(msg, args...)
 }
 
 // Warnf ...
 // Deprecated: Will be removed in future versions, use Warn instead.
-func Warnf(msg string, args ...interface{}) {
+func Warnf(msg string, args ...any) {
 	DefaultLogger.Warnf(msg, args...)
 }
 
 // Errorf ...
 // Deprecated: Will be removed in future versions, use Error instead.
-func Errorf(msg string, args ...interface{}) {
+func Errorf(msg string, args ...any) {
 	DefaultLogger.Errorf(msg, args...)
 }
 
 // Panicf ...
 // Deprecated: Will be removed in future versions, use Panic instead.
-func Panicf(msg string, args ...interface{}) {
+func Panicf(msg string, args ...any) {
 	DefaultLogger.Panicf(msg, args...)
 }
 
 // DPanicf ...
 // Deprecated: Will be removed in future versions, use DPanic instead.
-func DPanicf(msg string, args ...interface{}) {
+func DPanicf(msg string, args ...any) {
 	DefaultLogger.DPanicf(msg, args...)
 }
 
 // Fatalf ...
 // Deprecated: Will be removed in future versions, use Fatal instead.
-func Fatalf(msg string, args ...interface{}) {
+func Fatalf(msg string, args ...any) {
 	DefaultLogger.Fatalf(msg, args...)
 }
 

--- a/core/elog/elog_field.go
+++ b/core/elog/elog_field.go
@@ -86,7 +86,7 @@ func FieldValue(value string) Field {
 }
 
 // FieldValueAny ...
-func FieldValueAny(value interface{}) Field {
+func FieldValueAny(value any) Field {
 	return Any("value", value)
 }
 
@@ -101,7 +101,7 @@ func FieldErr(err error) Field {
 }
 
 // FieldErrAny ...
-func FieldErrAny(err interface{}) Field {
+func FieldErrAny(err any) Field {
 	return zap.Any("error", err)
 }
 
@@ -111,7 +111,7 @@ func FieldDescription(value string) Field {
 }
 
 // FieldExtMessage ...
-func FieldExtMessage(vals ...interface{}) Field {
+func FieldExtMessage(vals ...any) Field {
 	return zap.Any("ext", vals)
 }
 

--- a/core/elog/memory_encoder_test.go
+++ b/core/elog/memory_encoder_test.go
@@ -28,13 +28,13 @@ import (
 )
 
 // MapObjectEncoder is an ObjectEncoder backed by a simple
-// map[string]interface{}. It's not fast enough for production use, but it's
+// map[string]any. It's not fast enough for production use, but it's
 // helpful in tests.
 type MapObjectEncoder struct {
 	// Fields contains the entire encoded log context.
-	Fields map[string]interface{}
+	Fields map[string]any
 	// cur is a pointer to the namespace we're currently writing to.
-	cur map[string]interface{}
+	cur map[string]any
 }
 
 func (m *MapObjectEncoder) Clone() zapcore.Encoder {
@@ -47,7 +47,7 @@ func (m *MapObjectEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Fie
 
 // NewMapObjectEncoder creates a new map-backed ObjectEncoder.
 func NewMapObjectEncoder() *MapObjectEncoder {
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	return &MapObjectEncoder{
 		Fields: m,
 		cur:    m,
@@ -56,7 +56,7 @@ func NewMapObjectEncoder() *MapObjectEncoder {
 
 // AddArray implements ObjectEncoder.
 func (m *MapObjectEncoder) AddArray(key string, v zapcore.ArrayMarshaler) error {
-	arr := &sliceArrayEncoder{elems: make([]interface{}, 0)}
+	arr := &sliceArrayEncoder{elems: make([]any, 0)}
 	err := v.MarshalLogArray(arr)
 	m.cur[key] = arr.elems
 	return err
@@ -133,22 +133,22 @@ func (m *MapObjectEncoder) AddUint8(k string, v uint8) { m.cur[k] = v }
 func (m *MapObjectEncoder) AddUintptr(k string, v uintptr) { m.cur[k] = v }
 
 // AddReflected implements ObjectEncoder.
-func (m *MapObjectEncoder) AddReflected(k string, v interface{}) error {
+func (m *MapObjectEncoder) AddReflected(k string, v any) error {
 	m.cur[k] = v
 	return nil
 }
 
 // OpenNamespace implements ObjectEncoder.
 func (m *MapObjectEncoder) OpenNamespace(k string) {
-	ns := make(map[string]interface{})
+	ns := make(map[string]any)
 	m.cur[k] = ns
 	m.cur = ns
 }
 
-// sliceArrayEncoder is an ArrayEncoder backed by a simple []interface{}. Like
+// sliceArrayEncoder is an ArrayEncoder backed by a simple []any. Like
 // the MapObjectEncoder, it's not designed for production use.
 type sliceArrayEncoder struct {
-	elems []interface{}
+	elems []any
 }
 
 func (s *sliceArrayEncoder) AppendArray(v zapcore.ArrayMarshaler) error {
@@ -165,7 +165,7 @@ func (s *sliceArrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
 	return err
 }
 
-func (s *sliceArrayEncoder) AppendReflected(v interface{}) error {
+func (s *sliceArrayEncoder) AppendReflected(v any) error {
 	s.elems = append(s.elems, v)
 	return nil
 }

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -38,7 +38,7 @@ func CustomContextKeysLength() int {
 }
 
 // WithValue returns a new context with your key and value
-func WithValue(ctx context.Context, key string, value interface{}) context.Context {
+func WithValue(ctx context.Context, key string, value any) context.Context {
 	info := ctx.Value(key)
 	if info != nil {
 		return ctx
@@ -49,6 +49,6 @@ func WithValue(ctx context.Context, key string, value interface{}) context.Conte
 // Value returns value of your key
 // Deprecated
 // Use ctx.Value()
-func Value(ctx context.Context, key string) interface{} {
+func Value(ctx context.Context, key string) any {
 	return ctx.Value(key)
 }

--- a/core/util/xdebug/print.go
+++ b/core/util/xdebug/print.go
@@ -11,7 +11,7 @@ import (
 
 // MakeReqResInfo ...
 // Deprecated: MakeReqResInfo will be removed in v1.2
-func MakeReqResInfo(compName string, addr string, cost time.Duration, req interface{}, reply interface{}) string {
+func MakeReqResInfo(compName string, addr string, cost time.Duration, req any, reply any) string {
 	return fmt.Sprintf("%s %s %s %s => %s\n", xcolor.Green(compName), xcolor.Green(addr), xcolor.Yellow(fmt.Sprintf("[%vms]", float64(cost.Microseconds())/1000)), xcolor.Blue(fmt.Sprintf("%v", req)), xcolor.Blue(fmt.Sprintf("%v", reply)))
 }
 
@@ -23,7 +23,7 @@ func MakeReqResError(compName string, addr string, cost time.Duration, req strin
 
 // MakeReqResInfoV2 以info级别打印行号、配置名、目标地址、耗时、请求数据、响应数据
 // Deprecated: MakeReqResInfoV2 will be removed in v1.2
-func MakeReqResInfoV2(callerSkip int, compName string, addr string, cost time.Duration, req interface{}, reply interface{}) string {
+func MakeReqResInfoV2(callerSkip int, compName string, addr string, cost time.Duration, req any, reply any) string {
 	_, file, line, _ := runtime.Caller(callerSkip)
 	return fmt.Sprintf("%s %s %s %s %s => %s \n", xcolor.Green(file+":"+strconv.Itoa(line)), xcolor.Green(compName), xcolor.Green(addr), xcolor.Yellow(fmt.Sprintf("[%vms]", float64(cost.Microseconds())/1000)), xcolor.Blue(fmt.Sprintf("%v", req)), xcolor.Blue(fmt.Sprintf("%v", reply)))
 }
@@ -41,6 +41,6 @@ func MakeReqAndResError(line string, compName string, addr string, cost time.Dur
 }
 
 // MakeReqAndResInfo 以info级别打印行号、配置名、目标地址、耗时、请求数据、响应数据
-func MakeReqAndResInfo(line string, compName string, addr string, cost time.Duration, req interface{}, reply interface{}) string {
+func MakeReqAndResInfo(line string, compName string, addr string, cost time.Duration, req any, reply any) string {
 	return fmt.Sprintf("%s %s %s %s %s => %s", xcolor.Green(line), xcolor.Green(compName), xcolor.Green(addr), xcolor.Yellow(fmt.Sprintf("[%vms]", float64(cost.Microseconds())/1000)), xcolor.Blue(fmt.Sprintf("%v", req)), xcolor.Blue(fmt.Sprintf("%v", reply)))
 }

--- a/core/util/xmap/map.go
+++ b/core/util/xmap/map.go
@@ -8,7 +8,7 @@ import (
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
 var MergeStringMap = util.MergeStringMap
 
-// ToMapStringInterface cast map[interface{}]interface{} to map[string]interface{}
+// ToMapStringInterface cast map[any]any to map[string]any
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
 var ToMapStringInterface = util.ToMapStringInterface
 

--- a/core/util/xstring/function.go
+++ b/core/util/xstring/function.go
@@ -6,13 +6,13 @@ import (
 )
 
 // FunctionName returns the Function's name of given pointer.
-func FunctionName(i interface{}) string {
+func FunctionName(i any) string {
 	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 }
 
 // ObjectName returns the object's path and name of given pointer.
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
-func ObjectName(i interface{}) string {
+func ObjectName(i any) string {
 	typ := reflect.TypeOf(i)
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()

--- a/core/util/xstring/function_test.go
+++ b/core/util/xstring/function_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestFunctionName(t *testing.T) {
 	type args struct {
-		i interface{}
+		i any
 	}
 	tests := []struct {
 		name string
@@ -29,7 +29,7 @@ func TestFunctionName(t *testing.T) {
 
 func TestObjectName(t *testing.T) {
 	type args struct {
-		i interface{}
+		i any
 	}
 	tests := []struct {
 		name string

--- a/core/util/xstring/json.go
+++ b/core/util/xstring/json.go
@@ -45,25 +45,25 @@ func init() {
 }
 
 // JSON ...
-func JSON(obj interface{}) string {
+func JSON(obj any) string {
 	aa, _ := _jsonAPI.Marshal(obj)
 	return string(aa)
 }
 
 // JSONBytes ...
-func JSONBytes(obj interface{}) []byte {
+func JSONBytes(obj any) []byte {
 	aa, _ := _jsonAPI.Marshal(obj)
 	return aa
 }
 
 // PrettyJSON ...
-func PrettyJSON(obj interface{}) string {
+func PrettyJSON(obj any) string {
 	aa, _ := _jsonPrettyAPI.MarshalIndent(obj, "", "    ")
 	return string(aa)
 }
 
 // PrettyJSONBytes ...
-func PrettyJSONBytes(obj interface{}) []byte {
+func PrettyJSONBytes(obj any) []byte {
 	aa, _ := _jsonPrettyAPI.MarshalIndent(obj, "", "    ")
 	return aa
 }

--- a/examples/grpc/origin/server/main.go
+++ b/examples/grpc/origin/server/main.go
@@ -17,7 +17,7 @@ import (
 
 //  export EGO_DEBUG=true && go run main.go --config=config.toml
 func main() {
-	serverOptions := []grpc.ServerOption{grpc.ChainUnaryInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	serverOptions := []grpc.ServerOption{grpc.ChainUnaryInterceptor(func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		resp, err = handler(ctx, req)
 		fmt.Printf("resp--------------->"+"%+v\n", resp)
 		fmt.Printf("err--------------->"+"%+v\n", err)

--- a/examples/logger/ali/main.go
+++ b/examples/logger/ali/main.go
@@ -45,8 +45,8 @@ aliApiRetryMaxWaitTime = "3s" # ali api retry wait max wait time
 	log.Println("start to send logs to ali sls")
 
 	logger := elog.Load("ali").Build()
-	logger.Info("aaaaaaaaa", elog.Any("map", map[string]interface{}{"aaa": "AAA", "bbb": "BBB"}), elog.Any("slice", []string{"ccc", "ddd"}))
-	logger.Info("aaaaaaaaa", elog.Any("map", map[string]interface{}{"ccc": "CCC"}))
+	logger.Info("aaaaaaaaa", elog.Any("map", map[string]any{"aaa": "AAA", "bbb": "BBB"}), elog.Any("slice", []string{"ccc", "ddd"}))
+	logger.Info("aaaaaaaaa", elog.Any("map", map[string]any{"ccc": "CCC"}))
 	defer logger.Flush()
 
 	childLogger := logger.With(elog.String("prefix", "PREFIX"))

--- a/examples/logger/console/main.go
+++ b/examples/logger/console/main.go
@@ -8,7 +8,7 @@ import (
 //  export EGO_DEBUG=true && go run main.go
 func main() {
 	err := ego.New().Invoker(func() error {
-		elog.Info("logger info", elog.String("gopher", "ego"), elog.String("type", "command"), elog.Any("aaa", map[string]interface{}{"aa": "bb"}))
+		elog.Info("logger info", elog.String("gopher", "ego"), elog.String("type", "command"), elog.Any("aaa", map[string]any{"aa": "bb"}))
 		return nil
 	}).Run()
 	if err != nil {

--- a/internal/egrpcinteceptor/inteceptor.go
+++ b/internal/egrpcinteceptor/inteceptor.go
@@ -13,7 +13,7 @@ type messageType attribute.KeyValue
 
 // Event adds an event of the messageType to the span associated with the
 // passed context with id and size (if message is a proto message).
-func (m messageType) Event(ctx context.Context, id int, message interface{}) {
+func (m messageType) Event(ctx context.Context, id int, message any) {
 	span := trace.SpanFromContext(ctx)
 	if p, ok := message.(proto.Message); ok {
 		span.AddEvent("message", trace.WithAttributes(

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -54,20 +54,20 @@ func ContextValue(ctx context.Context, key string) string {
 	return cast.ToString(ctx.Value(key))
 }
 
-// ToSliceStringMap casts an empty interface to []map[string]interface{} ignoring error
-func ToSliceStringMap(i interface{}) []map[string]interface{} {
-	var s = make([]map[string]interface{}, 0)
+// ToSliceStringMap casts an empty interface to []map[string]any ignoring error
+func ToSliceStringMap(i any) []map[string]any {
+	var s = make([]map[string]any, 0)
 	switch v := i.(type) {
-	case []interface{}:
+	case []any:
 		for _, u := range v {
 			s = append(s, cast.ToStringMap(u))
 		}
 		return s
-	case []map[string]interface{}:
+	case []map[string]any:
 		s = append(s, v...)
 		return s
 	default:
-		log.Printf("unable to Cast %#v of type %v to []map[string]interface{}", i, reflect.TypeOf(i))
+		log.Printf("unable to Cast %#v of type %v to []map[string]any", i, reflect.TypeOf(i))
 		return s
 	}
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -59,10 +59,10 @@ func TestContextValueEmpty(t *testing.T) {
 }
 
 func TestToSliceStringMap(t *testing.T) {
-	out := ToSliceStringMap([]interface{}{
-		map[string]interface{}{"aaa": "AAA"},
+	out := ToSliceStringMap([]any{
+		map[string]any{"aaa": "AAA"},
 	})
-	assert.Equal(t, []map[string]interface{}{{"aaa": "AAA"}}, out)
+	assert.Equal(t, []map[string]any{{"aaa": "AAA"}}, out)
 }
 
 func TestGofmt(t *testing.T) {

--- a/internal/util/color_windows.go
+++ b/internal/util/color_windows.go
@@ -21,7 +21,7 @@ func Red(msg string) string {
 }
 
 // Redf ...
-func Redf(msg string, arg interface{}) string {
+func Redf(msg string, arg any) string {
 	return fmt.Sprintf("%s %+v\n", msg, arg)
 }
 
@@ -36,6 +36,6 @@ func Green(msg string) string {
 }
 
 // Greenf ...
-func Greenf(msg string, arg interface{}) string {
+func Greenf(msg string, arg any) string {
 	return fmt.Sprintf("%s %+v\n", msg, arg)
 }

--- a/internal/util/map.go
+++ b/internal/util/map.go
@@ -9,7 +9,7 @@ import (
 
 // MergeStringMap merge two map
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
-func MergeStringMap(dest, src map[string]interface{}) {
+func MergeStringMap(dest, src map[string]any) {
 	for sk, sv := range src {
 		tv, ok := dest[sk]
 		if !ok {
@@ -26,14 +26,14 @@ func MergeStringMap(dest, src map[string]interface{}) {
 		}
 
 		switch ttv := tv.(type) {
-		case map[interface{}]interface{}:
-			tsv := sv.(map[interface{}]interface{})
+		case map[any]any:
+			tsv := sv.(map[any]any)
 			ssv := ToMapStringInterface(tsv)
 			stv := ToMapStringInterface(ttv)
 			MergeStringMap(stv, ssv)
 			dest[sk] = stv
-		case map[string]interface{}:
-			MergeStringMap(ttv, sv.(map[string]interface{}))
+		case map[string]any:
+			MergeStringMap(ttv, sv.(map[string]any))
 			dest[sk] = ttv
 		default:
 			dest[sk] = sv
@@ -41,10 +41,10 @@ func MergeStringMap(dest, src map[string]interface{}) {
 	}
 }
 
-// ToMapStringInterface cast map[interface{}]interface{} to map[string]interface{}
+// ToMapStringInterface cast map[any]any to map[string]any
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
-func ToMapStringInterface(src map[interface{}]interface{}) map[string]interface{} {
-	tgt := map[string]interface{}{}
+func ToMapStringInterface(src map[any]any) map[string]any {
+	tgt := map[string]any{}
 	for k, v := range src {
 		tgt[fmt.Sprintf("%v", k)] = v
 	}
@@ -53,15 +53,15 @@ func ToMapStringInterface(src map[interface{}]interface{}) map[string]interface{
 
 // DeepSearchInMap deep search in map
 // Deprecated: this function will be moved to internal package, user should not use it anymore.
-func DeepSearchInMap(m map[string]interface{}, paths ...string) map[string]interface{} {
-	mtmp := make(map[string]interface{})
+func DeepSearchInMap(m map[string]any, paths ...string) map[string]any {
+	mtmp := make(map[string]any)
 	for k, v := range m {
 		mtmp[k] = v
 	}
 	for _, k := range paths {
 		m2, ok := mtmp[k]
 		if !ok {
-			m3 := make(map[string]interface{})
+			m3 := make(map[string]any)
 			mtmp[k] = m3
 			mtmp = m3
 			continue
@@ -69,7 +69,7 @@ func DeepSearchInMap(m map[string]interface{}, paths ...string) map[string]inter
 
 		m3, err := cast.ToStringMapE(m2)
 		if err != nil {
-			m3 = make(map[string]interface{})
+			m3 = make(map[string]any)
 			mtmp[k] = m3
 		}
 		// continue search

--- a/internal/util/map_test.go
+++ b/internal/util/map_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestMergeStringMap(t *testing.T) {
 	type args struct {
-		dest map[string]interface{}
-		src  map[string]interface{}
-		tar  map[string]interface{}
+		dest map[string]any
+		src  map[string]any
+		tar  map[string]any
 	}
 	tests := []struct {
 		name string
@@ -20,48 +20,48 @@ func TestMergeStringMap(t *testing.T) {
 		{
 			name: "二维测试",
 			args: args{
-				dest: map[string]interface{}{
-					"2w": map[string]interface{}{
+				dest: map[string]any{
+					"2w": map[string]any{
 						"test":  "2wtd",
 						"test1": "2wtd1",
 					},
-					"2wa": map[string]interface{}{
+					"2wa": map[string]any{
 						"test":  "2wtd",
 						"test1": "2wtd1",
 					},
-					"2wi": map[interface{}]interface{}{
+					"2wi": map[any]any{
 						"test":  "2wtd",
 						"test1": "2wtd1",
 					},
 				},
-				src: map[string]interface{}{
-					"2w": map[string]interface{}{
+				src: map[string]any{
+					"2w": map[string]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
-					"2wb": map[string]interface{}{
+					"2wb": map[string]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
-					"2wi": map[interface{}]interface{}{
+					"2wi": map[any]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
 				},
-				tar: map[string]interface{}{
-					"2w": map[string]interface{}{
+				tar: map[string]any{
+					"2w": map[string]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
-					"2wb": map[string]interface{}{
+					"2wb": map[string]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
-					"2wa": map[string]interface{}{
+					"2wa": map[string]any{
 						"test":  "2wtd",
 						"test1": "2wtd1",
 					},
-					"2wi": map[string]interface{}{
+					"2wi": map[string]any{
 						"test":  "2wtds",
 						"test1": "2wtd1s",
 					},
@@ -71,15 +71,15 @@ func TestMergeStringMap(t *testing.T) {
 		{
 			name: "一维测试",
 			args: args{
-				dest: map[string]interface{}{
+				dest: map[string]any{
 					"1w":  "tt",
 					"1wa": "mq",
 				},
-				src: map[string]interface{}{
+				src: map[string]any{
 					"1w":  "tts",
 					"1wb": "bq",
 				},
-				tar: map[string]interface{}{
+				tar: map[string]any{
 					"1w":  "tts",
 					"1wa": "mq",
 					"1wb": "bq",
@@ -100,18 +100,18 @@ func TestMergeStringMap(t *testing.T) {
 
 func TestDeepSearchInMap(t *testing.T) {
 	type args struct {
-		m     map[string]interface{}
+		m     map[string]any
 		paths []string
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string]interface{}
+		want map[string]any
 	}{
 		{
 			name: "test",
-			args: args{map[string]interface{}{"key1": map[string]interface{}{"subkey1": "subval1"}}, []string{"key1"}},
-			want: map[string]interface{}{"subkey1": "subval1"},
+			args: args{map[string]any{"key1": map[string]any{"subkey1": "subval1"}}, []string{"key1"}},
+			want: map[string]any{"subkey1": "subval1"},
 		},
 	}
 	for _, tt := range tests {
@@ -125,17 +125,17 @@ func TestDeepSearchInMap(t *testing.T) {
 
 func TestToMapStringInterface(t *testing.T) {
 	type args struct {
-		src map[interface{}]interface{}
+		src map[any]any
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string]interface{}
+		want map[string]any
 	}{
 		{
 			name: "test",
-			args: args{map[interface{}]interface{}{1: 1}},
-			want: map[string]interface{}{"1": 1},
+			args: args{map[any]any{1: 1}},
+			want: map[string]any{"1": 1},
 		},
 	}
 	for _, tt := range tests {
@@ -149,13 +149,13 @@ func TestToMapStringInterface(t *testing.T) {
 
 func TestDeepSearchInMap1(t *testing.T) {
 	type args struct {
-		m     map[string]interface{}
+		m     map[string]any
 		paths []string
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string]interface{}
+		want map[string]any
 	}{
 		// TODO: Add test cases.
 	}
@@ -170,8 +170,8 @@ func TestDeepSearchInMap1(t *testing.T) {
 
 func TestMergeStringMap1(t *testing.T) {
 	type args struct {
-		dest map[string]interface{}
-		src  map[string]interface{}
+		dest map[string]any
+		src  map[string]any
 	}
 	tests := []struct {
 		name string
@@ -188,12 +188,12 @@ func TestMergeStringMap1(t *testing.T) {
 
 func TestToMapStringInterface1(t *testing.T) {
 	type args struct {
-		src map[interface{}]interface{}
+		src map[any]any
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string]interface{}
+		want map[string]any
 	}{
 		// TODO: Add test cases.
 	}

--- a/server/egin/component_websocket_test.go
+++ b/server/egin/component_websocket_test.go
@@ -15,16 +15,16 @@ import (
 
 // simpleBufferPool is an implementation of BufferPool for TestWriteBufferPool.
 type simpleBufferPool struct {
-	v interface{}
+	v any
 }
 
-func (p *simpleBufferPool) Get() interface{} {
+func (p *simpleBufferPool) Get() any {
 	v := p.v
 	p.v = nil
 	return v
 }
 
-func (p *simpleBufferPool) Put(v interface{}) {
+func (p *simpleBufferPool) Put(v any) {
 	p.v = v
 }
 

--- a/server/egin/config.go
+++ b/server/egin/config.go
@@ -112,6 +112,6 @@ func (config *Config) ClientAuthType() tls.ClientAuthType {
 	}
 }
 
-func defaultRecoveryFunc(ctx *gin.Context, _ interface{}) {
+func defaultRecoveryFunc(ctx *gin.Context, _ any) {
 	ctx.AbortWithStatus(http.StatusInternalServerError)
 }

--- a/server/egin/grpc_proxy.go
+++ b/server/egin/grpc_proxy.go
@@ -57,7 +57,7 @@ func protoError(c *gin.Context, code int, e error) ([]byte, error) {
 }
 
 // protoJSON sends a Protobuf JSON response with status code and data.
-func protoJSON(c *gin.Context, code int, i interface{}) ([]byte, error) {
+func protoJSON(c *gin.Context, code int, i any) ([]byte, error) {
 	var acceptEncoding = c.Request.Header.Get(HeaderAcceptEncoding)
 	var ok bool
 	var m proto.Message
@@ -81,7 +81,7 @@ func protoJSON(c *gin.Context, code int, i interface{}) ([]byte, error) {
 }
 
 // GRPCProxy experimental
-func GRPCProxy(h interface{}) gin.HandlerFunc {
+func GRPCProxy(h any) gin.HandlerFunc {
 	t := reflect.TypeOf(h)
 	if t.Kind() != reflect.Func {
 		panic("reflect error: handler must be func")

--- a/server/egin/interceptor.go
+++ b/server/egin/interceptor.go
@@ -170,12 +170,12 @@ func (c *Container) defaultServerInterceptor() gin.HandlerFunc {
 
 				if c.config.EnableAccessInterceptorReq && out {
 					if len(rb.String()) > c.config.AccessInterceptorReqMaxLength {
-						fields = append(fields, elog.Any("req", map[string]interface{}{
+						fields = append(fields, elog.Any("req", map[string]any{
 							"metadata": copyHeaders(ctx.Request.Header),
 							"payload":  rb.String()[:c.config.AccessInterceptorReqMaxLength] + "...",
 						}))
 					} else {
-						fields = append(fields, elog.Any("req", map[string]interface{}{
+						fields = append(fields, elog.Any("req", map[string]any{
 							"metadata": copyHeaders(ctx.Request.Header),
 							"payload":  rb.String(),
 						}))
@@ -183,12 +183,12 @@ func (c *Container) defaultServerInterceptor() gin.HandlerFunc {
 				}
 				if c.config.EnableAccessInterceptorRes && out {
 					if len(rw.body.String()) > c.config.AccessInterceptorResMaxLength {
-						fields = append(fields, elog.Any("res", map[string]interface{}{
+						fields = append(fields, elog.Any("res", map[string]any{
 							"metadata": copyHeaders(ctx.Request.Header),
 							"payload":  rw.body.String()[:c.config.AccessInterceptorResMaxLength] + "...",
 						}))
 					} else {
-						fields = append(fields, elog.Any("res", map[string]interface{}{
+						fields = append(fields, elog.Any("res", map[string]any{
 							"metadata": copyHeaders(ctx.Writer.Header()),
 							"payload":  rw.body.String(),
 						}))
@@ -482,7 +482,7 @@ func (c *Container) checkFilter(req *http.Request, rw *resWriter) bool {
 	if c.config.aiReqResCelPrg == nil {
 		return true
 	}
-	out, _, err := c.config.aiReqResCelPrg.Eval(map[string]interface{}{
+	out, _, err := c.config.aiReqResCelPrg.Eval(map[string]any{
 		"request":  convert2googleRequest(req),
 		"response": convert2googleResponse(rw),
 	})

--- a/server/egin/interceptor_gzip.go
+++ b/server/egin/interceptor_gzip.go
@@ -56,7 +56,7 @@ func newGzipHandler(level int, options ...GzipOption) *gzipHandler {
 	handler := &gzipHandler{
 		GzipOptions: DefaultOptions,
 		gzPool: sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				gz, err := gzip.NewWriterLevel(io.Discard, level)
 				if err != nil {
 					panic(err)

--- a/server/egin/interceptor_test.go
+++ b/server/egin/interceptor_test.go
@@ -44,7 +44,7 @@ func TestPanicInHandler(t *testing.T) {
 	assert.NoError(t, err)
 	// 虽然程序里返回200，只要panic就会为500
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	var m map[string]interface{}
+	var m map[string]any
 	n := strings.Index(string(logged), "{")
 	err1 := json.Unmarshal(logged[n:], &m)
 	assert.NoError(t, err1)
@@ -68,7 +68,7 @@ func TestPanicInCustomHandler(t *testing.T) {
 	)
 
 	// 自定义 recover
-	var recoverFunc gin.RecoveryFunc = func(ctx *gin.Context, err interface{}) {
+	var recoverFunc gin.RecoveryFunc = func(ctx *gin.Context, err any) {
 		ctx.String(http.StatusInternalServerError, "%v", err)
 		ctx.Abort()
 	}
@@ -89,7 +89,7 @@ func TestPanicInCustomHandler(t *testing.T) {
 	// TEST
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, panicMessage, w.Body.String())
-	var m map[string]interface{}
+	var m map[string]any
 	n := strings.Index(string(logged), "{")
 	err1 := json.Unmarshal(logged[n:], &m)
 	assert.NoError(t, err1)

--- a/server/egrpc/config.go
+++ b/server/egrpc/config.go
@@ -33,8 +33,8 @@ type Config struct {
 	serverOptions                 []grpc.ServerOption
 	streamInterceptors            []grpc.StreamServerInterceptor
 	unaryInterceptors             []grpc.UnaryServerInterceptor
-	unaryServerResourceExtract    func(context.Context, interface{}, *grpc.UnaryServerInfo) string // sentinel 的限流策略
-	unaryServerBlockFallback      func(context.Context, interface{}, *grpc.UnaryServerInfo, *base.BlockError) (interface{}, error)
+	unaryServerResourceExtract    func(context.Context, any, *grpc.UnaryServerInfo) string // sentinel 的限流策略
+	unaryServerBlockFallback      func(context.Context, any, *grpc.UnaryServerInfo, *base.BlockError) (any, error)
 }
 
 // DefaultConfig represents default config

--- a/server/egrpc/interceptor.go
+++ b/server/egrpc/interceptor.go
@@ -58,7 +58,7 @@ func traceUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		egrpcinteceptor.RPCSystemGRPC,
 		egrpcinteceptor.GRPCKindUnary,
 	}
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (reply interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (reply any, err error) {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			md = metadata.New(nil)
@@ -96,7 +96,7 @@ type contextedServerStream struct {
 	sentMessageID     int
 }
 
-func (css *contextedServerStream) RecvMsg(m interface{}) error {
+func (css *contextedServerStream) RecvMsg(m any) error {
 	err := css.ServerStream.RecvMsg(m)
 
 	if err == nil {
@@ -107,7 +107,7 @@ func (css *contextedServerStream) RecvMsg(m interface{}) error {
 	return err
 }
 
-func (css *contextedServerStream) SendMsg(m interface{}) error {
+func (css *contextedServerStream) SendMsg(m any) error {
 	err := css.ServerStream.SendMsg(m)
 
 	css.sentMessageID++
@@ -127,7 +127,7 @@ func traceStreamServerInterceptor() grpc.StreamServerInterceptor {
 		semconv.RPCSystemKey.String("grpc"),
 		egrpcinteceptor.GRPCKindStream,
 	}
-	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		md, ok := metadata.FromIncomingContext(ss.Context())
 		if !ok {
 			md = metadata.New(nil)
@@ -161,7 +161,7 @@ func traceStreamServerInterceptor() grpc.StreamServerInterceptor {
 }
 
 func (c *Container) defaultStreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
 		var beg = time.Now()
 		var fields []elog.Field
 		var event = "normal"
@@ -264,7 +264,7 @@ func CtxStoreSet(ctx context.Context, k string, v any) {
 }
 
 func (c *Container) defaultUnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res interface{}, err error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (res any, err error) {
 		ctx = context.WithValue(ctx, ctxStoreStruct{}, &ctxStore{kvs: map[string]any{}})
 		// 默认过滤掉该探活日志
 		if c.config.EnableSkipHealthLog && info.FullMethod == "/grpc.health.v1.Health/Check" {
@@ -463,10 +463,10 @@ func getPeerIpFromContext(ctx context.Context) string {
 func (c *Container) sentinelInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		// method as resource name by default
 		resourceName := info.FullMethod
 		if c.config.unaryServerResourceExtract != nil {

--- a/server/egrpc/interceptor_test.go
+++ b/server/egrpc/interceptor_test.go
@@ -242,7 +242,7 @@ func (g PanicGreeter) SayHello(context context.Context, request *helloworld.Hell
 
 func TestCtxStoreSet(t *testing.T) {
 	ctx := context.Background()
-	Ctx := context.WithValue(ctx, ctxStoreStruct{}, &ctxStore{kvs: make(map[string]interface{})})
+	Ctx := context.WithValue(ctx, ctxStoreStruct{}, &ctxStore{kvs: make(map[string]any)})
 	CtxStore := Ctx.Value(ctxStoreStruct{}).(*ctxStore)
 	assert.NotNil(t, CtxStore)
 	CtxStoreSet(Ctx, "hello", "world")

--- a/server/egrpc/opitons.go
+++ b/server/egrpc/opitons.go
@@ -46,14 +46,14 @@ func WithUnaryInterceptor(interceptors ...grpc.UnaryServerInterceptor) Option {
 }
 
 // WithUnaryServerResourceExtractor sets the resource extractor of unary server request.
-func WithUnaryServerResourceExtractor(fn func(context.Context, interface{}, *grpc.UnaryServerInfo) string) Option {
+func WithUnaryServerResourceExtractor(fn func(context.Context, any, *grpc.UnaryServerInfo) string) Option {
 	return func(c *Container) {
 		c.config.unaryServerResourceExtract = fn
 	}
 }
 
 // WithUnaryServerBlockFallback sets the block fallback handler of unary server request.
-func WithUnaryServerBlockFallback(fn func(context.Context, interface{}, *grpc.UnaryServerInfo, *base.BlockError) (interface{}, error)) Option {
+func WithUnaryServerBlockFallback(fn func(context.Context, any, *grpc.UnaryServerInfo, *base.BlockError) (any, error)) Option {
 	return func(c *Container) {
 		c.config.unaryServerBlockFallback = fn
 	}

--- a/server/egrpc/options_test.go
+++ b/server/egrpc/options_test.go
@@ -33,7 +33,7 @@ func TestWithServerOption(t *testing.T) {
 }
 
 func TestWithStreamInterceptor(t *testing.T) {
-	intcp := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	intcp := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return nil
 	}
 	opt := WithStreamInterceptor(intcp)
@@ -43,7 +43,7 @@ func TestWithStreamInterceptor(t *testing.T) {
 }
 
 func TestWithUnaryInterceptor(t *testing.T) {
-	intcp := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+	intcp := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp any, err error) {
 		return nil, nil
 	}
 	opt := WithUnaryInterceptor(intcp)

--- a/server/server.go
+++ b/server/server.go
@@ -53,7 +53,7 @@ func (si ServiceInfo) Label() string {
 }
 
 // Equal 一定要实现这个方法，在gRPC的attributes里会使用该方法断言，判断是否相等
-func (si ServiceInfo) Equal(o interface{}) bool {
+func (si ServiceInfo) Equal(o any) bool {
 	return reflect.DeepEqual(si, o)
 }
 

--- a/task/ecron/wrappedlogger.go
+++ b/task/ecron/wrappedlogger.go
@@ -9,11 +9,11 @@ type wrappedLogger struct {
 }
 
 // Info logs routine messages about cron's operation.
-func (wl *wrappedLogger) Info(msg string, keysAndValues ...interface{}) {
+func (wl *wrappedLogger) Info(msg string, keysAndValues ...any) {
 	wl.Component.ZapSugaredLogger().Infow("cron "+msg, keysAndValues...)
 }
 
 // Error logs an error condition.
-func (wl *wrappedLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+func (wl *wrappedLogger) Error(err error, msg string, keysAndValues ...any) {
 	wl.Component.ZapSugaredLogger().Errorw("cron "+msg, append(keysAndValues, "err", err)...)
 }


### PR DESCRIPTION
Replace all `interface{}` type literals with `any` (available since Go 1.18).

The codebase already uses Go 1.21, so this is safe.

38 files, 194 replacements.